### PR TITLE
Port to python source

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,11 +6,13 @@ The purpose of this project is to create a telegram bot that collects github not
 ** Dependencies
    - python3
    - [[http://docs.hylang.org/en/stable/][hy3]]
+   - syslog-ng (>= 3.18)
 
 ** Installation
-   - Install syslog-ng (=< 3.16) :)
+   - Install syslog-ng (=> 3.18)
    - Copy the configuration file into etc
-   - Copy the hy script into sbin
+   - Copy the hy scripts into sbin
+   - Alternatively you work from a git clone, but setting PYTHONPATH in the service file.
    - Edit configuration: insert github api user and api key, telegram api key and chat id.
 * Tests
 #+BEGIN_SRC sh

--- a/github-notificator.conf
+++ b/github-notificator.conf
@@ -1,18 +1,25 @@
-@version: 3.16
+@version: 3.17
 
 @include "scl/telegram/telegram.conf"
 
-source s_github_reader {
-    program("hy3 githubnotificationfetcher.hy [github user] [github api key]" flags(no-parse));
+@define telegram-api-key "bot-api-key"
+@define telegram-chat-id "telegram-chat-id"
+@define github-user "github-user"
+@define github-api-key "github-api-key"
+
+source githubnotification_source {
+    python(class(githubnotificationsource.GithubNotificationSource)
+           options("username" "`github-user`" "api_token" "`github-api-key`")
+           loaders(hy) flags(no-parse));
 };
 
 destination d_telegram {
   telegram(
-    bot-id("[bot api key]")
-    chat-id("[chat id]"));
+    bot-id("`telegram-api-key`")
+    chat-id("`telegram-chat-id`"));
 };
 
 log {
-    source (s_github_reader);
+    source (githubnotification_source);
     destination (d_telegram);
 };

--- a/githubnotificationfetcher.hy
+++ b/githubnotificationfetcher.hy
@@ -16,13 +16,12 @@
           (.decode
             (.request githubconn latest-comment-url) "utf-8")))
 
-  (urllib.parse.quote
-    (.format "title: {}\ntype: {}\nuser: {}\nmessage: {}\nlink: {}\n"
+  (.format "title: {}\ntype: {}\nuser: {}\nmessage: {}\nlink: {}\n"
              (get notification "subject" "title")
              (get notification "subject" "type")
              (get latest-comment "user" "login")
              (get latest-comment "body")
-             (get latest-comment "html_url"))))
+             (get latest-comment "html_url")))
 
 (defn parse-notifications [notifications-json githubconn]
   (setv notifications (json.loads (.decode notifications-json "utf-8")))

--- a/githubnotificationfetcher.hy
+++ b/githubnotificationfetcher.hy
@@ -3,7 +3,6 @@
 (import urllib.parse)
 (import http.client urllib.parse)
 (import base64)
-(import sys)
 
 (defn format-single-notification [notification githubconn]
 
@@ -69,24 +68,3 @@
   (.disconnect githubconn)
 
   notifications)
-
-(defmacro loop [&rest body]
-  `(while 1
-     (do ~@body)))
-
-(defmacro periodically [seconds &rest body]
-  `(loop
-     (do ~@body
-         (time.sleep ~seconds))))
-
-(defmain [&rest args]
-  (time.sleep 120)
-
-  (setv username (get sys.argv 1)
-        api-token (get sys.argv 2))
-
-  (periodically
-    300
-   (for [notification (fetch-notifications username api-token)]
-     (print notification))
-   (sys.stdout.flush)))

--- a/githubnotificationsource.hy
+++ b/githubnotificationsource.hy
@@ -1,6 +1,7 @@
 (import sys)
 (import syslogng threading)
 (import githubnotificationfetcher)
+(import traceback)
 
 (defclass GithubNotificationSource [syslogng.LogSource]
   (defn init [self options]
@@ -14,9 +15,12 @@
   (defn run [self]
     (while (not self.exit)
 
-      (for [notification (githubnotificationfetcher.fetch-notifications self.username self.api-token)]
-        (self.post_message (syslogng.LogMessage notification)))
-      (sys.stdout.flush)
+      (try
+        (for [notification (githubnotificationfetcher.fetch-notifications self.username self.api-token)]
+          (self.post_message (syslogng.LogMessage notification)))
+        (sys.stdout.flush)
+        (except [e Exception]
+          (traceback.print_exc)))
 
       (self.event.wait 300)))
 

--- a/githubnotificationsource.hy
+++ b/githubnotificationsource.hy
@@ -1,0 +1,25 @@
+(import sys)
+(import syslogng threading)
+(import githubnotificationfetcher)
+
+(defclass GithubNotificationSource [syslogng.LogSource]
+  (defn init [self options]
+    (setv self.event (threading.Event)
+          self.exit False)
+
+    (setv self.username (get options "username")
+          self.api-token (get options "api_token"))
+    True)
+
+  (defn run [self]
+    (while (not self.exit)
+
+      (for [notification (githubnotificationfetcher.fetch-notifications self.username self.api-token)]
+        (self.post_message (syslogng.LogMessage notification)))
+      (sys.stdout.flush)
+
+      (self.event.wait 300)))
+
+   (defn request-exit [self]
+     (setv self.exit True)
+     (self.event.set)))

--- a/test_githubnotificationbot.py
+++ b/test_githubnotificationbot.py
@@ -47,7 +47,7 @@ def http_server():
 def test_format_notification(http_server):
     githubconn = GithubConnection("testuser", "testpass")
     githubconn.connect("localhost:5555", context=ssl._create_unverified_context())
-    result = format_notifications(githubconn.request("/notifications"), githubconn)
-    assert "test_title" in result
-    assert "comment_body" in result
+    notifications = parse_notifications(githubconn.request("/notifications"), githubconn)
+    assert "test_title" in notifications[0]
+    assert "comment_body" in notifications[0]
     githubconn.disconnect()


### PR DESCRIPTION
The code is rewritten so that github notification bot use the newly introduced [python source](https://github.com/balabit/syslog-ng/pull/2308) framework in syslog-ng, instead of being a program source.

With this, one can avoid a decoding pipeline: program source used to send messages as urlencoded, that needed to be urldecoded first). Now the messages are posted to the core directly.